### PR TITLE
feat: just one letter by word and more words

### DIFF
--- a/src/crossword-data.js
+++ b/src/crossword-data.js
@@ -1,25 +1,29 @@
 export const crosswordData = {
-    grid: [
-      ['R', 'E', 'A', 'C', 'T'],
-      [0, 0, 'C', 0, 0],
-      [0, 0, 'T', 0, 0],
-      [0, 0, 'O', 0, 0],
-      [0, 0, 'R', 0, 0],
+  grid: [
+    ['R', '', 'A', '', 'T'],
+    [0, 0, '', '', ''],
+    [0, 0, '', '', ''],
+    [0, 0, '', 0, 0],
+    ['C', '', '', 0, 0],
+  ],
+  clues: {
+    across: [
+      '1. A popular JavaScript library for building user interfaces.',
+      '3. A road vehicle, typically with four wheels.',
     ],
-    clues: {
+    down: [
+      '2. A person who performs in a play or movie.',
+      '4. Abbreviation for Tuesday.',
+    ],
+  },
+  answers: {
       across: [
-        '1. A popular JavaScript library for building user interfaces.',
+          'REACT',
+          'CAR'
       ],
       down: [
-        '1. A tool that transpiles JavaScript files.',
-      ],
-    },
-    answers: {
-        across: [
-            'REACT'
-        ],
-        down: [
-            'ACTOR'
-        ]
-    }
-  };
+          'ACTOR',
+          'TUE'
+      ]
+  }
+};


### PR DESCRIPTION
Prompt: The design is good now, but all the words are coming filled and are just showing two words, please fix to add more words and without being filled(just one letter by word to have a tip).

Result: 
<img width="1419" height="781" alt="image" src="https://github.com/user-attachments/assets/87f3d99d-6a86-419c-834e-48c0eb27a3d7" />

Next steps: Now we need to implement the number tips in each row/column, and add a feedback if the answer is correct.