### PR TITLE
feat: number tips and feedback alert

### DIFF
--- a/src/components/Crossword.css
+++ b/src/components/Crossword.css
@@ -10,11 +10,20 @@
 }
 
 .cell {
+  position: relative;
   width: 40px;
   height: 40px;
   border: 1px solid black;
   text-align: center;
   font-size: 24px;
+}
+
+.clue-number {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  font-size: 12px;
+  font-weight: bold;
 }
 
 .cell input {
@@ -24,6 +33,7 @@
   font-size: 24px;
   border: none;
   padding: 0;
+  background: transparent;
 }
 
 .clues {

--- a/src/components/Crossword.js
+++ b/src/components/Crossword.js
@@ -1,15 +1,53 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import './Crossword.css';
 
 const Crossword = ({ data }) => {
   const [grid, setGrid] = useState(data.grid);
-  const numCols = data.grid[0].length;
+  const [clueNumbers, setClueNumbers] = useState({});
+
+  useEffect(() => {
+    const newClueNumbers = {};
+    Object.keys(data.clues.across).forEach((number) => {
+      const { row, col } = data.clues.across[number];
+      newClueNumbers[`${row}-${col}`] = number;
+    });
+    Object.keys(data.clues.down).forEach((number) => {
+      const { row, col } = data.clues.down[number];
+      newClueNumbers[`${row}-${col}`] = number;
+    });
+    setClueNumbers(newClueNumbers);
+  }, [data.clues]);
 
   const handleChange = (e, row, col) => {
     const newGrid = [...grid];
     newGrid[row][col] = e.target.value.toUpperCase();
     setGrid(newGrid);
+
+    checkAnswers(newGrid);
   };
+
+  const checkAnswers = (currentGrid) => {
+    Object.keys(data.clues.across).forEach((number) => {
+      const { answer, row, col } = data.clues.across[number];
+      const word = currentGrid[row].slice(col, col + answer.length).join('');
+      if (word === answer) {
+        alert(`Correct! Across clue ${number}: ${answer}`);
+      }
+    });
+
+    Object.keys(data.clues.down).forEach((number) => {
+      const { answer, row, col } = data.clues.down[number];
+      let word = '';
+      for (let i = 0; i < answer.length; i++) {
+        word += currentGrid[row + i][col];
+      }
+      if (word === answer) {
+        alert(`Correct! Down clue ${number}: ${answer}`);
+      }
+    });
+  };
+
+  const numCols = data.grid[0].length;
 
   return (
     <div className="crossword">
@@ -17,8 +55,11 @@ const Crossword = ({ data }) => {
         {grid.flat().map((cell, index) => {
           const row = Math.floor(index / numCols);
           const col = index % numCols;
+          const clueNumber = clueNumbers[`${row}-${col}`];
+
           return (
             <div key={`${row}-${col}`} className="cell">
+              {clueNumber && <span className="clue-number">{clueNumber}</span>}
               {cell !== 0 && (
                 <input
                   type="text"
@@ -34,14 +75,14 @@ const Crossword = ({ data }) => {
       <div className="clues">
         <div className="across">
           <h3>Across</h3>
-          {data.clues.across.map((clue, index) => (
-            <div key={index}>{clue}</div>
+          {Object.entries(data.clues.across).map(([number, { clue }]) => (
+            <div key={number}>{`${number}. ${clue}`}</div>
           ))}
         </div>
         <div className="down">
           <h3>Down</h3>
-          {data.clues.down.map((clue, index) => (
-            <div key={index}>{clue}</div>
+          {Object.entries(data.clues.down).map(([number, { clue }]) => (
+            <div key={number}>{`${number}. ${clue}`}</div>
           ))}
         </div>
       </div>

--- a/src/crossword-data.js
+++ b/src/crossword-data.js
@@ -7,23 +7,33 @@ export const crosswordData = {
     ['C', '', '', 0, 0],
   ],
   clues: {
-    across: [
-      '1. A popular JavaScript library for building user interfaces.',
-      '3. A road vehicle, typically with four wheels.',
-    ],
-    down: [
-      '2. A person who performs in a play or movie.',
-      '4. Abbreviation for Tuesday.',
-    ],
+    across: {
+      1: {
+        clue: 'A popular JavaScript library for building user interfaces.',
+        answer: 'REACT',
+        row: 0,
+        col: 0,
+      },
+      3: {
+        clue: 'A road vehicle, typically with four wheels.',
+        answer: 'CAR',
+        row: 4,
+        col: 0,
+      },
+    },
+    down: {
+      2: {
+        clue: 'A person who performs in a play or movie.',
+        answer: 'ACTOR',
+        row: 0,
+        col: 2,
+      },
+      4: {
+        clue: 'Abbreviation for Tuesday.',
+        answer: 'TUE',
+        row: 0,
+        col: 4,
+      },
+    },
   },
-  answers: {
-      across: [
-          'REACT',
-          'CAR'
-      ],
-      down: [
-          'ACTOR',
-          'TUE'
-      ]
-  }
 };


### PR DESCRIPTION
Prompt: Now we need to implement the number tips in each row/column, and add a feedback if the answer is correct.

Alert result: 
<img width="1422" height="778" alt="image" src="https://github.com/user-attachments/assets/7c25ed79-aac0-4810-83b3-29540d323582" />

Next steps: I don't specified what kind of feedback i want, so it was showing an alert, i want to change this to a better way of feedback, coloring the row/column background with green color. And also adding random words instead fixed words.